### PR TITLE
ci: GitHub Actions lint, format, and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: make lint
+
+  format:
+    name: format
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SwiftFormat
+        run: brew install swiftformat
+
+      - name: Check formatting
+        run: make format-check
+
+  test:
+    name: test
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: make test

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,5 @@
+# SwiftFormat config — keep aligned with Make / CI (`make format` / `make format-check`).
+--swiftversion 5.9
+--indent 2
+--disable wrapMultilineStatementBraces
+--exclude .build,.swiftpm,Scripts

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,23 @@
+# Starter config — tighten once the word list leaves the source file.
+disabled_rules:
+  - line_length
+  - file_length
+  - type_body_length
+  - function_body_length
+  - todo
+
+opt_in_rules:
+  - empty_count
+  - sorted_imports
+
+included:
+  - .
+  - Sources
+  - Tests
+
+excluded:
+  - .build
+  - .swiftpm
+  - Scripts
+
+reporter: xcode

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY: lint format format-check test hash-wordlist check-word reveal-wordlist help
+
+# SwiftLint needs a full Xcode toolchain (SourceKit), not bare Command Line Tools.
+XCODE_DEVELOPER := $(shell ls -d /Applications/Xcode*.app/Contents/Developer 2>/dev/null | sort | tail -1)
+ifneq ($(XCODE_DEVELOPER),)
+export DEVELOPER_DIR ?= $(XCODE_DEVELOPER)
+endif
+
+help:
+	@echo "Targets:"
+	@echo "  make lint            Run SwiftLint"
+	@echo "  make format          Apply SwiftFormat"
+	@echo "  make format-check    SwiftFormat --lint (CI)"
+	@echo "  make test            Run swift test (no-op until Package.swift exists)"
+	@echo "  make hash-wordlist   Hash plaintext word list (engine PR)"
+	@echo "  make check-word WORD=…  Probe membership (engine PR)"
+	@echo "  make reveal-wordlist Show local plaintext word list if present"
+
+lint:
+	swiftlint lint --config .swiftlint.yml
+
+format:
+	swiftformat .
+
+format-check:
+	swiftformat --lint .
+
+test:
+	@if [ -f Package.swift ]; then \
+		swift test; \
+	else \
+		echo "No Package.swift yet; skipping tests (add the SPM package next)."; \
+	fi
+
+hash-wordlist:
+	@echo "hash-wordlist will be implemented with the censor engine PR." >&2
+	@exit 1
+
+check-word:
+	@echo "check-word will be implemented with the censor engine PR. WORD='$(WORD)'" >&2
+	@exit 1
+
+reveal-wordlist:
+	@echo "reveal-wordlist will be implemented with the censor engine PR." >&2
+	@exit 1

--- a/ProfanityFilter.swift
+++ b/ProfanityFilter.swift
@@ -7,14 +7,12 @@ import Foundation
 // yourLabel.text = ProfanityFilter.cleanUp("your string")
 
 class ProfanityFilter: NSObject {
-  
   /* Words from https://www.freewebheaders.com/full-list-of-bad-words-banned-by-google/ */
-  
+
   static func cleanUp(_ string: String) -> String {
     let dirtyWords = "\\b(2g1c|2 girls 1 cup|acrotomophilia|alabama hot pocket|alaskan pipeline|anal|anilingus|anus|apeshit|arsehole|ass|asshole|assmunch|auto erotic|autoerotic|babeland|baby batter|baby juice|ball gag|ball gravy|ball kicking|ball licking|ball sack|ball sucking|bangbros|bareback|barely legal|barenaked|bastard|bastardo|bastinado|bbw|bdsm|beaner|beaners|beaver cleaver|beaver lips|bestiality|big black|big breasts|big knockers|big tits|bimbos|birdlock|bitch|bitches|black cock|blonde action|blonde on blonde action|blowjob|blow job|blow your load|blue waffle|blumpkin|bollocks|bondage|boner|boob|boobs|booty call|brown showers|brunette action|bukkake|bulldyke|bullet vibe|bullshit|bung hole|bunghole|busty|butt|buttcheeks|butthole|camel toe|camgirl|camslut|camwhore|carpet muncher|carpetmuncher|chocolate rosebuds|circlejerk|cleveland steamer|clit|clitoris|clover clamps|clusterfuck|cock|cocks|coprolagnia|coprophilia|cornhole|coon|coons|creampie|cum|cumming|cunnilingus|cunt|darkie|date rape|daterape|deep throat|deepthroat|dendrophilia|dick|dildo|dingleberry|dingleberries|dirty pillows|dirty sanchez|doggie style|doggiestyle|doggy style|doggystyle|dog style|dolcett|domination|dominatrix|dommes|donkey punch|double dong|double penetration|dp action|dry hump|dvda|eat my ass|ecchi|ejaculation|erotic|erotism|escort|eunuch|faggot|fecal|felch|fellatio|feltch|female squirting|femdom|figging|fingerbang|fingering|fisting|foot fetish|footjob|frotting|fuck|fuck buttons|fuckin|fucking|fucktards|fudge packer|fudgepacker|futanari|gang bang|gay sex|genitals|giant cock|girl on|girl on top|girls gone wild|goatcx|goatse|god damn|gokkun|golden shower|goodpoop|goo girl|goregasm|grope|group sex|g-spot|guro|hand job|handjob|hard core|hardcore|hentai|homoerotic|honkey|hooker|hot carl|hot chick|how to kill|how to murder|huge fat|humping|incest|intercourse|jack off|jail bait|jailbait|jelly donut|jerk off|jigaboo|jiggaboo|jiggerboo|jizz|juggs|kike|kinbaku|kinkster|kinky|knobbing|leather restraint|leather straight jacket|lemon party|lolita|lovemaking|make me come|male squirting|masturbate|menage a trois|mf|milf|missionary position|mofo|motherfucker|mound of venus|mr hands|muff diver|muffdiving|nambla|nawashi|negro|neonazi|nigga|nigger|nig nog|nimphomania|nipple|nipples|nsfw images|nude|nudity|nympho|nymphomania|octopussy|omorashi|one cup two girls|one guy one jar|orgasm|orgy|paedophile|paki|panties|panty|pedobear|pedophile|pegging|penis|phone sex|piece of shit|pissing|piss pig|pisspig|playboy|pleasure chest|pole smoker|ponyplay|poof|poon|poontang|punany|poop chute|poopchute|porn|porno|pornography|prince albert piercing|pthc|pubes|pussy|queaf|queef|quim|raghead|raging boner|rape|raping|rapist|rectum|reverse cowgirl|rimjob|rimming|rosy palm|rosy palm and her 5 sisters|rusty trombone|sadism|santorum|scat|schlong|scissoring|semen|sex|sexo|sexy|shaved beaver|shaved pussy|shemale|shibari|shit|shitblimp|shitty|shota|shrimping|skeet|slanteye|slut|s&m|smut|snatch|snowballing|sodomize|sodomy|spic|splooge|splooge moose|spooge|spread legs|spunk|strap on|strapon|strappado|strip club|style doggy|suck|sucks|suicide girls|sultry women|swastika|swinger|tainted love|taste my|tea bagging|threesome|throating|tied up|tight white|tit|tits|titties|titty|tongue in a|topless|tosser|towelhead|tranny|tribadism|tub girl|tubgirl|tushy|twat|twink|twinkie|two girls one cup|undressing|upskirt|urethra play|urophilia|vagina|venus mound|vibrator|violet wand|vorarephilia|voyeur|vulva|wank|wetback|wet dream|white power|wrapping men|wrinkled starfish|xx|xxx|yaoi|yellow showers|yiffy|zoophilia|🖕)\\b"
-    
+
     func matches(for regex: String, in text: String) -> [String] {
-      
       do {
         let regex = try NSRegularExpression(pattern: regex)
         let results = regex.matches(in: text,
@@ -22,24 +20,24 @@ class ProfanityFilter: NSObject {
         return results.compactMap {
           Range($0.range, in: text).map { String(text[$0]) }
         }
-      } catch let error {
+      } catch {
         print("invalid regex: \(error.localizedDescription)")
         return []
       }
     }
-    
+
     let dirtyWordMatches = matches(for: dirtyWords, in: string)
-    
-    if dirtyWordMatches.count == 0 {
+
+    if dirtyWordMatches.isEmpty {
       return string
     } else {
       var newString = string
-      
-      dirtyWordMatches.forEach({ dirtyWord in
+
+      for dirtyWord in dirtyWordMatches {
         let newWord = String(repeating: "😲", count: dirtyWord.count)
         newString = newString.replacingOccurrences(of: dirtyWord, with: newWord, options: [.caseInsensitive])
-      })
-      
+      }
+
       return newString
     }
   }


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with separate **lint**, **format**, and **test** jobs (not one blob)
- Add SwiftLint + SwiftFormat configs and a root `Makefile` (`make lint` / `format` / `format-check` / `test`)
- CI jobs call Make targets; `make test` skips cleanly until `Package.swift` lands
- Small formatting / `isEmpty` cleanup so current sources pass the new gates

## Test plan
- [ ] PR checks show three independent jobs: `lint`, `format`, `test`
- [ ] All three jobs are green
- [ ] Locally: `make lint`, `make format-check`, `make test` (test skips without Package.swift)


Made with [Cursor](https://cursor.com)