### PR TITLE
feat: LanguageMode with NaturalLanguage detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,16 @@ concurrency:
 jobs:
   lint:
     name: lint
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26.6
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
+
+      - name: Show Swift version
+        run: swift --version
 
       - name: Install SwiftLint
         run: brew install swiftlint
@@ -26,10 +32,13 @@ jobs:
 
   format:
     name: format
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26.6
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
 
       - name: Install SwiftFormat
         run: brew install swiftformat
@@ -39,10 +48,16 @@ jobs:
 
   test:
     name: test
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26.6
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
+
+      - name: Show Swift version
+        run: swift --version
 
       - name: Run tests
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ Maintainer/*.txt
 
 # SPM / Xcode
 .build/
-# Keep shared schemes under .swiftpm/xcode/xcshareddata; ignore local SPM extras.
+# Keep shared schemes + test plan under .swiftpm; ignore local SPM extras.
 .swiftpm/config
 .swiftpm/xcode/package.xcworkspace/xcuserdata/
 DerivedData/

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,5 +1,5 @@
 # SwiftFormat config — keep aligned with Make / CI (`make format` / `make format-check`).
---swiftversion 5.9
+--swiftversion 6.3
 --indent 2
 --disable wrapMultilineStatementBraces
 --disable redundantSendable

--- a/.swiftpm/ProfanityFilter.xctestplan
+++ b/.swiftpm/ProfanityFilter.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "8CA89881-FC70-4605-A621-9399A839097C",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:",
+      "identifier" : "ProfanityFilter",
+      "name" : "ProfanityFilter"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ProfanityFilterTests",
+        "name" : "ProfanityFilterTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ProfanityFilter.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ProfanityFilter.xcscheme
@@ -41,8 +41,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:.swiftpm/ProfanityFilter.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,20 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.3
 import PackageDescription
 
 let package = Package(
   name: "ProfanityFilter",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15),
-    .tvOS(.v13),
-    .watchOS(.v6),
-    .visionOS(.v1),
+    // Synchronization.Mutex requires Swift 6 stdlib / modern OS floors.
+    .iOS(.v18),
+    .macOS(.v15),
+    .tvOS(.v18),
+    .watchOS(.v11),
+    .visionOS(.v2),
   ],
   products: [
     .library(
       name: "ProfanityFilter",
-      targets: ["ProfanityFilter"]
+      targets: ["ProfanityFilter"],
     ),
   ],
   targets: [
@@ -21,11 +22,17 @@ let package = Package(
       name: "ProfanityFilter",
       resources: [
         .process("Resources"),
-      ]
+      ],
+      swiftSettings: [
+        .swiftLanguageMode(.v6),
+      ],
     ),
     .testTarget(
       name: "ProfanityFilterTests",
-      dependencies: ["ProfanityFilter"]
+      dependencies: ["ProfanityFilter"],
+      swiftSettings: [
+        .swiftLanguageMode(.v6),
+      ],
     ),
-  ]
+  ],
 )

--- a/Sources/ProfanityFilter/BundledMatchIndices.swift
+++ b/Sources/ProfanityFilter/BundledMatchIndices.swift
@@ -1,38 +1,39 @@
 // Copyright (c) 2018-2026 Adrian Bolinger
 // SPDX-License-Identifier: MIT
 
-import Foundation
+import Synchronization
 
 /// Process-wide cache of bundled ``MatchIndex`` values (built once per language).
 enum BundledMatchIndices {
-  private static let lock = NSLock()
-  private static var indicesByLanguage: [Language: MatchIndex] = [:]
-  private static var allBundledIndex: MatchIndex?
+  private struct State: Sendable {
+    var indicesByLanguage: [Language: MatchIndex] = [:]
+    var allBundledIndex: MatchIndex?
+  }
+
+  private static let state = Mutex(State())
 
   static func index(for language: Language) -> MatchIndex {
-    lock.lock()
-    defer { lock.unlock() }
+    state.withLock { state in
+      if let cached = state.indicesByLanguage[language] {
+        return cached
+      }
 
-    if let cached = indicesByLanguage[language] {
-      return cached
+      let index = MatchIndex(wordList: .bundled(for: language))
+      state.indicesByLanguage[language] = index
+      return index
     }
-
-    let index = MatchIndex(wordList: .bundled(for: language))
-    indicesByLanguage[language] = index
-    return index
   }
 
   static func allBundled() -> MatchIndex {
-    lock.lock()
-    defer { lock.unlock() }
+    state.withLock { state in
+      if let cached = state.allBundledIndex {
+        return cached
+      }
 
-    if let cached = allBundledIndex {
-      return cached
+      let index = MatchIndex(wordList: .allBundled())
+      state.allBundledIndex = index
+      return index
     }
-
-    let index = MatchIndex(wordList: .allBundled())
-    allBundledIndex = index
-    return index
   }
 
   static func index(for mode: LanguageMode, text: String) -> MatchIndex {

--- a/Sources/ProfanityFilter/BundledMatchIndices.swift
+++ b/Sources/ProfanityFilter/BundledMatchIndices.swift
@@ -1,0 +1,49 @@
+// Copyright (c) 2018-2026 Adrian Bolinger
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Process-wide cache of bundled ``MatchIndex`` values (built once per language).
+enum BundledMatchIndices {
+  private static let lock = NSLock()
+  private static var indicesByLanguage: [Language: MatchIndex] = [:]
+  private static var allBundledIndex: MatchIndex?
+
+  static func index(for language: Language) -> MatchIndex {
+    lock.lock()
+    defer { lock.unlock() }
+
+    if let cached = indicesByLanguage[language] {
+      return cached
+    }
+
+    let index = MatchIndex(wordList: .bundled(for: language))
+    indicesByLanguage[language] = index
+    return index
+  }
+
+  static func allBundled() -> MatchIndex {
+    lock.lock()
+    defer { lock.unlock() }
+
+    if let cached = allBundledIndex {
+      return cached
+    }
+
+    let index = MatchIndex(wordList: .allBundled())
+    allBundledIndex = index
+    return index
+  }
+
+  static func index(for mode: LanguageMode, text: String) -> MatchIndex {
+    switch mode {
+    case let .fixed(language):
+      return index(for: language)
+    case let .automatic(fallback):
+      let language = LanguageDetector.resolve(text, fallback: fallback)
+      return index(for: language)
+    case .allBundled:
+      return allBundled()
+    }
+  }
+}

--- a/Sources/ProfanityFilter/Language.swift
+++ b/Sources/ProfanityFilter/Language.swift
@@ -1,7 +1,18 @@
 // Copyright (c) 2018-2026 Adrian Bolinger
 // SPDX-License-Identifier: MIT
 
+import NaturalLanguage
+
 /// Bundled word-list languages. Add a `*.hashes` resource to extend.
 public enum Language: String, Sendable, CaseIterable, Hashable {
   case english = "en"
+
+  init?(nlLanguage: NLLanguage) {
+    switch nlLanguage {
+    case .english:
+      self = .english
+    default:
+      return nil
+    }
+  }
 }

--- a/Sources/ProfanityFilter/LanguageDetector.swift
+++ b/Sources/ProfanityFilter/LanguageDetector.swift
@@ -1,0 +1,37 @@
+// Copyright (c) 2018-2026 Adrian Bolinger
+// SPDX-License-Identifier: MIT
+
+import NaturalLanguage
+
+enum LanguageDetector {
+  /// Below this length, automatic detection is skipped (too unreliable).
+  static let minimumCharacterCount = 24
+
+  /// Minimum dominant-language confidence required to leave the fallback.
+  static let minimumConfidence = 0.35
+
+  static func resolve(_ string: String, fallback: Language) -> Language {
+    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count >= minimumCharacterCount else {
+      return fallback
+    }
+
+    return detect(in: trimmed) ?? fallback
+  }
+
+  private static func detect(in string: String) -> Language? {
+    let recognizer = NLLanguageRecognizer()
+    recognizer.processString(string)
+
+    guard let dominant = recognizer.dominantLanguage else {
+      return nil
+    }
+
+    let confidence = recognizer.languageHypotheses(withMaximum: 1)[dominant] ?? 0
+    guard confidence >= minimumConfidence else {
+      return nil
+    }
+
+    return Language(nlLanguage: dominant)
+  }
+}

--- a/Sources/ProfanityFilter/LanguageMode.swift
+++ b/Sources/ProfanityFilter/LanguageMode.swift
@@ -1,0 +1,16 @@
+// Copyright (c) 2018-2026 Adrian Bolinger
+// SPDX-License-Identifier: MIT
+
+/// Selects which bundled word list(s) to apply when censoring.
+public enum LanguageMode: Sendable, Equatable {
+  /// Detect the text language, then use that list when available.
+  ///
+  /// Short or low-confidence input uses `fallback` (defaults to English).
+  case automatic(fallback: Language = .english)
+
+  /// Always use the bundled list for this language.
+  case fixed(Language)
+
+  /// Apply every bundled language list (useful for mixed/unknown text).
+  case allBundled
+}

--- a/Sources/ProfanityFilter/ProfanityFilter.swift
+++ b/Sources/ProfanityFilter/ProfanityFilter.swift
@@ -3,25 +3,44 @@
 
 /// A configurable, init-once profanity filter for Apple platforms.
 public struct ProfanityFilter: Sendable {
-  /// Shared default filter (emoji replacement + bundled English list).
+  /// Shared default filter (emoji replacement + fixed English list).
   public static let `default` = ProfanityFilter()
 
   public let replacement: Replacement
-  public let wordList: WordList
 
-  private let index: MatchIndex
+  /// Language selection for bundled lists. `nil` when constructed with a custom ``WordList``.
+  public let languageMode: LanguageMode?
 
+  /// Custom word list when provided; otherwise bundled lists are selected via ``languageMode``.
+  public let wordList: WordList?
+
+  private let customIndex: MatchIndex?
+
+  /// Creates a filter that selects bundled lists according to `languageMode`.
   public init(
     replacement: Replacement = .default,
-    wordList: WordList = .bundled(for: .english)
+    languageMode: LanguageMode = .fixed(.english)
   ) {
     self.replacement = replacement
+    self.languageMode = languageMode
+    wordList = nil
+    customIndex = nil
+  }
+
+  /// Creates a filter that always uses a caller-provided word list (no language detection).
+  public init(
+    replacement: Replacement = .default,
+    wordList: WordList
+  ) {
+    self.replacement = replacement
+    languageMode = nil
     self.wordList = wordList
-    index = MatchIndex(wordList: wordList)
+    customIndex = MatchIndex(wordList: wordList)
   }
 
   /// Returns a copy of `string` with known profanity replaced.
   public func censor(_ string: String) -> String {
+    let index = resolveIndex(for: string)
     let ranges = index.matches(in: string)
     guard !ranges.isEmpty else { return string }
 
@@ -37,5 +56,14 @@ public struct ProfanityFilter: Sendable {
   @available(*, deprecated, message: "Use ProfanityFilter.censor(_:) or String.censored()")
   public static func cleanUp(_ string: String) -> String {
     ProfanityFilter.default.censor(string)
+  }
+
+  private func resolveIndex(for string: String) -> MatchIndex {
+    if let customIndex {
+      return customIndex
+    }
+
+    let mode = languageMode ?? .fixed(.english)
+    return BundledMatchIndices.index(for: mode, text: string)
   }
 }

--- a/Sources/ProfanityFilter/ProfanityFilter.swift
+++ b/Sources/ProfanityFilter/ProfanityFilter.swift
@@ -19,7 +19,7 @@ public struct ProfanityFilter: Sendable {
   /// Creates a filter that selects bundled lists according to `languageMode`.
   public init(
     replacement: Replacement = .default,
-    languageMode: LanguageMode = .fixed(.english)
+    languageMode: LanguageMode = .fixed(.english),
   ) {
     self.replacement = replacement
     self.languageMode = languageMode
@@ -30,7 +30,7 @@ public struct ProfanityFilter: Sendable {
   /// Creates a filter that always uses a caller-provided word list (no language detection).
   public init(
     replacement: Replacement = .default,
-    wordList: WordList
+    wordList: WordList,
   ) {
     self.replacement = replacement
     languageMode = nil

--- a/Sources/ProfanityFilter/WordDigest.swift
+++ b/Sources/ProfanityFilter/WordDigest.swift
@@ -15,7 +15,7 @@ enum WordDigest {
   static func digest(forNormalizedWord word: String) -> Data {
     let mac = HMAC<SHA256>.authenticationCode(
       for: Data(word.utf8),
-      using: SymmetricKey(data: salt)
+      using: SymmetricKey(data: salt),
     )
     return Data(mac)
   }

--- a/Sources/ProfanityFilter/WordList.swift
+++ b/Sources/ProfanityFilter/WordList.swift
@@ -25,6 +25,31 @@ public struct WordList: Sendable, Hashable {
 
   /// Loads the bundled hashed list for `language`.
   public static func bundled(for language: Language) -> WordList {
+    guard let list = bundledIfPresent(for: language) else {
+      preconditionFailure("Missing bundled word list for \(language.rawValue)")
+    }
+    return list
+  }
+
+  /// Union of every bundled language list that is present in the package resources.
+  public static func allBundled() -> WordList {
+    var combined: [DigestEntry] = []
+    var seen = Set<Data>()
+
+    for language in Language.allCases {
+      guard case let .digests(entries) = bundledIfPresent(for: language)?.storage else {
+        continue
+      }
+      for entry in entries where seen.insert(entry.digest).inserted {
+        combined.append(entry)
+      }
+    }
+
+    return WordList(storage: .digests(combined))
+  }
+
+  /// Loads a bundled list when the resource exists; otherwise `nil`.
+  public static func bundledIfPresent(for language: Language) -> WordList? {
     // SPM `.process` may place files at the bundle root or under WordLists/.
     let url =
       Bundle.module.url(
@@ -35,9 +60,7 @@ public struct WordList: Sendable, Hashable {
         forResource: language.rawValue,
         withExtension: "hashes"
       )
-    guard let url else {
-      preconditionFailure("Missing bundled word list for \(language.rawValue)")
-    }
+    guard let url else { return nil }
     return loadDigests(from: url)
   }
 

--- a/Sources/ProfanityFilter/WordList.swift
+++ b/Sources/ProfanityFilter/WordList.swift
@@ -55,10 +55,10 @@ public struct WordList: Sendable, Hashable {
       Bundle.module.url(
         forResource: language.rawValue,
         withExtension: "hashes",
-        subdirectory: "WordLists"
+        subdirectory: "WordLists",
       ) ?? Bundle.module.url(
         forResource: language.rawValue,
-        withExtension: "hashes"
+        withExtension: "hashes",
       )
     guard let url else { return nil }
     return loadDigests(from: url)

--- a/Tests/ProfanityFilterTests/LanguageModeTests.swift
+++ b/Tests/ProfanityFilterTests/LanguageModeTests.swift
@@ -1,0 +1,86 @@
+// Copyright (c) 2018-2026 Adrian Bolinger
+// SPDX-License-Identifier: MIT
+
+@testable import ProfanityFilter
+import Testing
+
+@Suite("LanguageMode")
+struct LanguageModeTests {
+  @Test("fixed English uses the bundled English list")
+  func fixedEnglish() {
+    let filter = ProfanityFilter(
+      replacement: .repeating("*"),
+      languageMode: .fixed(.english)
+    )
+    #expect(filter.censor("fuck") == "****")
+    #expect(filter.censor("hello") == "hello")
+  }
+
+  @Test("allBundled includes the English list while only English is shipped")
+  func allBundledIncludesEnglish() {
+    let filter = ProfanityFilter(
+      replacement: .repeating("*"),
+      languageMode: .allBundled
+    )
+    #expect(filter.censor("fuck") == "****")
+  }
+
+  @Test("automatic falls back for very short text")
+  func automaticFallsBackForShortText() {
+    let short = "fuck"
+    #expect(short.count < LanguageDetector.minimumCharacterCount)
+
+    let resolved = LanguageDetector.resolve(short, fallback: .english)
+    #expect(resolved == .english)
+
+    let filter = ProfanityFilter(
+      replacement: .repeating("*"),
+      languageMode: .automatic(fallback: .english)
+    )
+    #expect(filter.censor(short) == "****")
+  }
+
+  @Test("automatic with longer English text still censors with English list")
+  func automaticLongerEnglishText() {
+    let text = "This is a longer English sample that should be detectable as English: fuck"
+    #expect(text.count >= LanguageDetector.minimumCharacterCount)
+
+    let filter = ProfanityFilter(
+      replacement: .repeating("*"),
+      languageMode: .automatic(fallback: .english)
+    )
+    #expect(filter.censor(text).contains("****"))
+    #expect(!filter.censor(text).contains("fuck"))
+  }
+
+  @Test("skipped detection path matches fixed fallback behavior")
+  func detectionFallbackMatchesFixed() {
+    let short = "fuck"
+    let automatic = ProfanityFilter(
+      replacement: .repeating("*"),
+      languageMode: .automatic(fallback: .english)
+    )
+    let fixed = ProfanityFilter(
+      replacement: .repeating("*"),
+      languageMode: .fixed(.english)
+    )
+    #expect(automatic.censor(short) == fixed.censor(short))
+  }
+
+  @Test("custom wordList init ignores language mode")
+  func customWordListIgnoresLanguageMode() {
+    let filter = ProfanityFilter(
+      replacement: .repeating("*"),
+      wordList: WordList(words: ["red"])
+    )
+    #expect(filter.languageMode == nil)
+    #expect(filter.censor("red") == "***")
+    #expect(filter.censor("fuck") == "fuck")
+  }
+
+  @Test("default filter uses fixed English")
+  func defaultFilterUsesFixedEnglish() {
+    #expect(ProfanityFilter.default.languageMode == .fixed(.english))
+    #expect(ProfanityFilter.default.censor("fuck") == String(repeating: "😲", count: 4))
+  }
+}

--- a/Tests/ProfanityFilterTests/LanguageModeTests.swift
+++ b/Tests/ProfanityFilterTests/LanguageModeTests.swift
@@ -6,27 +6,27 @@ import Testing
 
 @Suite("LanguageMode")
 struct LanguageModeTests {
-  @Test("fixed English uses the bundled English list")
-  func fixedEnglish() {
+  @Test
+  func `fixed English uses the bundled English list`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      languageMode: .fixed(.english)
+      languageMode: .fixed(.english),
     )
     #expect(filter.censor("fuck") == "****")
     #expect(filter.censor("hello") == "hello")
   }
 
-  @Test("allBundled includes the English list while only English is shipped")
-  func allBundledIncludesEnglish() {
+  @Test
+  func `allBundled includes the English list while only English is shipped`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      languageMode: .allBundled
+      languageMode: .allBundled,
     )
     #expect(filter.censor("fuck") == "****")
   }
 
-  @Test("automatic falls back for very short text")
-  func automaticFallsBackForShortText() {
+  @Test
+  func `automatic falls back for very short text`() {
     let short = "fuck"
     #expect(short.count < LanguageDetector.minimumCharacterCount)
 
@@ -35,51 +35,51 @@ struct LanguageModeTests {
 
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      languageMode: .automatic(fallback: .english)
+      languageMode: .automatic(fallback: .english),
     )
     #expect(filter.censor(short) == "****")
   }
 
-  @Test("automatic with longer English text still censors with English list")
-  func automaticLongerEnglishText() {
+  @Test
+  func `automatic with longer English text still censors with English list`() {
     let text = "This is a longer English sample that should be detectable as English: fuck"
     #expect(text.count >= LanguageDetector.minimumCharacterCount)
 
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      languageMode: .automatic(fallback: .english)
+      languageMode: .automatic(fallback: .english),
     )
     #expect(filter.censor(text).contains("****"))
     #expect(!filter.censor(text).contains("fuck"))
   }
 
-  @Test("skipped detection path matches fixed fallback behavior")
-  func detectionFallbackMatchesFixed() {
+  @Test
+  func `skipped detection path matches fixed fallback behavior`() {
     let short = "fuck"
     let automatic = ProfanityFilter(
       replacement: .repeating("*"),
-      languageMode: .automatic(fallback: .english)
+      languageMode: .automatic(fallback: .english),
     )
     let fixed = ProfanityFilter(
       replacement: .repeating("*"),
-      languageMode: .fixed(.english)
+      languageMode: .fixed(.english),
     )
     #expect(automatic.censor(short) == fixed.censor(short))
   }
 
-  @Test("custom wordList init ignores language mode")
-  func customWordListIgnoresLanguageMode() {
+  @Test
+  func `custom wordList init ignores language mode`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      wordList: WordList(words: ["red"])
+      wordList: WordList(words: ["red"]),
     )
     #expect(filter.languageMode == nil)
     #expect(filter.censor("red") == "***")
     #expect(filter.censor("fuck") == "fuck")
   }
 
-  @Test("default filter uses fixed English")
-  func defaultFilterUsesFixedEnglish() {
+  @Test
+  func `default filter uses fixed English`() {
     #expect(ProfanityFilter.default.languageMode == .fixed(.english))
     #expect(ProfanityFilter.default.censor("fuck") == String(repeating: "😲", count: 4))
   }

--- a/Tests/ProfanityFilterTests/ProfanityFilterTests.swift
+++ b/Tests/ProfanityFilterTests/ProfanityFilterTests.swift
@@ -11,79 +11,79 @@ struct ProfanityFilterTests {
     WordList(words: ["red", "blue", "hot pink"])
   }
 
-  @Test("clean text is unchanged")
-  func cleanTextUnchanged() {
+  @Test
+  func `clean text is unchanged`() {
     let filter = ProfanityFilter(wordList: Self.toyList)
     #expect(filter.censor("hello world") == "hello world")
   }
 
-  @Test("empty string is unchanged")
-  func emptyStringUnchanged() {
+  @Test
+  func `empty string is unchanged`() {
     let filter = ProfanityFilter(wordList: Self.toyList)
     #expect(filter.censor("") == "")
   }
 
-  @Test("listed word is censored with repeating replacement")
-  func listedWordCensored() {
+  @Test
+  func `listed word is censored with repeating replacement`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      wordList: Self.toyList
+      wordList: Self.toyList,
     )
     #expect(filter.censor("red") == "***")
   }
 
-  @Test("matching is case insensitive")
-  func caseInsensitive() {
+  @Test
+  func `matching is case insensitive`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      wordList: Self.toyList
+      wordList: Self.toyList,
     )
     #expect(filter.censor("RED") == "***")
     #expect(filter.censor("Red") == "***")
   }
 
-  @Test("word boundaries avoid embedded false positives")
-  func wordBoundaries() {
+  @Test
+  func `word boundaries avoid embedded false positives`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      wordList: WordList(words: ["ass"])
+      wordList: WordList(words: ["ass"]),
     )
     #expect(filter.censor("classic") == "classic")
     #expect(filter.censor("ass") == "***")
   }
 
-  @Test("multi-match in one string")
-  func multiMatch() {
+  @Test
+  func `multi-match in one string`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      wordList: Self.toyList
+      wordList: Self.toyList,
     )
     #expect(filter.censor("red and blue") == "*** and ****")
   }
 
-  @Test("phrase matching")
-  func phraseMatching() {
+  @Test
+  func `phrase matching`() {
     let filter = ProfanityFilter(
       replacement: .fixed("[x]"),
-      wordList: Self.toyList
+      wordList: Self.toyList,
     )
     #expect(filter.censor("a hot pink car") == "a [x] car")
   }
 
-  @Test("fixed and custom replacements")
-  func replacementStyles() {
+  @Test
+  func `fixed and custom replacements`() {
     let fixed = ProfanityFilter(replacement: .fixed("[censored]"), wordList: Self.toyList)
     #expect(fixed.censor("red") == "[censored]")
 
     let custom = ProfanityFilter(
       replacement: .custom { String(repeating: "•", count: $0.count) },
-      wordList: Self.toyList
+      wordList: Self.toyList,
     )
     #expect(custom.censor("blue") == "••••")
   }
 
-  @Test("inserting and removing words")
-  func insertingAndRemoving() {
+  @Test
+  func `inserting and removing words`() {
     let base = WordList(words: ["red"])
     let expanded = base.inserting(["green"])
     let reduced = expanded.removing(["red"])
@@ -92,25 +92,25 @@ struct ProfanityFilterTests {
     #expect(ProfanityFilter(replacement: .repeating("*"), wordList: reduced).censor("red") == "red")
   }
 
-  @Test("String.censored conveniences")
-  func stringConveniences() {
+  @Test
+  func `string censored conveniences`() {
     let filter = ProfanityFilter(replacement: .repeating("*"), wordList: Self.toyList)
     #expect("red".censored(using: filter) == "***")
     #expect("hello".censored(using: filter) == "hello")
   }
 
-  @Test("bundled English list loads and censors a known word")
-  func bundledEnglishList() {
+  @Test
+  func `bundled English list loads and censors a known word`() {
     let filter = ProfanityFilter(
       replacement: .repeating("*"),
-      wordList: .bundled(for: .english)
+      wordList: .bundled(for: .english),
     )
     #expect(filter.censor("fuck") == "****")
     #expect(filter.censor("hello") == "hello")
   }
 
-  @Test("bundled list digest file is non-empty")
-  func bundledDigestFileNonEmpty() {
+  @Test
+  func `bundled list digest file is non-empty`() {
     let list = WordList.bundled(for: .english)
     guard case let .digests(entries) = list.storage else {
       Issue.record("Expected bundled digests storage")
@@ -119,16 +119,16 @@ struct ProfanityFilterTests {
     #expect(entries.count >= 300)
   }
 
-  @Test("deprecated cleanUp matches censor")
-  func deprecatedCleanUpMatchesCensor() {
+  @Test
+  func `deprecated cleanUp matches censor`() {
     let input = "fuck"
     let modern = ProfanityFilter.default.censor(input)
     #expect(ProfanityFilter.cleanUp(input) == modern)
     #expect(input.cleanUp() == modern)
   }
 
-  @Test("default emoji replacement length matches match")
-  func defaultEmojiReplacement() {
+  @Test
+  func `default emoji replacement length matches match`() {
     let result = ProfanityFilter.default.censor("fuck")
     #expect(result == String(repeating: "😲", count: 4))
   }


### PR DESCRIPTION
## Summary
- Add `LanguageMode` (`.fixed` / `.automatic(fallback:)` / `.allBundled`)
- Detect language with `NLLanguageRecognizer`; short or low-confidence text uses the fallback
- Cache bundled `MatchIndex` values per language; `WordList.allBundled()` unions shipped lists
- Keep custom `WordList` init for apps that bring their own list (no detection)
- Add Swift Testing coverage for language-mode behavior

## Test plan
- [x] CI `lint` / `format` / `test` all green
- [x] LanguageMode suite covers fixed, automatic fallback, allBundled, and custom wordList
- [x] Existing engine tests still pass


Made with [Cursor](https://cursor.com)