### PR TITLE
docs: README, DocC, and maintainer guide for 1.0

### DIFF
--- a/Maintainer/README.md
+++ b/Maintainer/README.md
@@ -1,13 +1,36 @@
 # Maintainer word lists
 
-Plaintext corpora live here locally and are **gitignored**.
+Plaintext corpora live here locally and are **gitignored**. The package ships only salted digests under `Sources/ProfanityFilter/Resources/WordLists/`.
 
-1. Edit `Maintainer/en.txt` (one word/phrase per line; `#` comments allowed)
-2. Run `make hash-wordlist` to regenerate `Sources/ProfanityFilter/Resources/WordLists/en.hashes`
-3. Commit only the `.hashes` file
+## Update the English list
 
-Probe membership without printing the corpus:
+1. Edit `Maintainer/en.txt` (one word or phrase per line; `#` comments allowed).
+2. Regenerate digests:
+
+   ```bash
+   make hash-wordlist
+   ```
+
+3. Commit **only** `Sources/ProfanityFilter/Resources/WordLists/en.hashes` (never the `.txt`).
+
+## Probe membership
+
+Check whether a word hashes into the committed set without printing the corpus:
 
 ```bash
 make check-word WORD=example
 ```
+
+## Show local plaintext
+
+```bash
+make reveal-wordlist
+```
+
+Fails if `Maintainer/en.txt` is missing (expected on a fresh clone).
+
+## Add another language later
+
+1. Add `Maintainer/<code>.txt` and wire `make hash-wordlist` (or a dedicated target) to emit `Sources/ProfanityFilter/Resources/WordLists/<code>.hashes`.
+2. Add a `Language` case whose `rawValue` matches the file stem (e.g. `es` → `es.hashes`).
+3. Extend `Language` ↔ `NLLanguage` mapping in `LanguageDetector` when automatic detection should pick it up.

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,11 +1,123 @@
-
-
 # ProfanityFilter
-Filtro de lenguaje inapropiado escrito en Swift utilizando NSRegularExpressions
 
-Ejemplo de uso:
+Filtro de lenguaje inapropiado configurable, en el dispositivo, para plataformas Apple. Construye un índice una vez (digests con sal) y sustituye coincidencias con el estilo que elijas.
 
-    let testWord = "naughty"
+[English](README.md)
 
-    // returns "😲😲😲😲😲😲😲"
-    let cleanedUpWord = ProfanityFilter.cleanUp(testWord)
+## Requisitos
+
+- Swift 6.3+
+- iOS 18+ / macOS 15+ / tvOS 18+ / watchOS 11+ / visionOS 2+
+
+## Instalación
+
+Añade el paquete en Xcode (**File → Add Package Dependencies…**) o en `Package.swift`:
+
+```swift
+dependencies: [
+  .package(url: "https://github.com/AdrianBinDC/ProfanityFilter.git", from: "1.0.0"),
+],
+```
+
+Luego declara el producto:
+
+```swift
+.product(name: "ProfanityFilter", package: "ProfanityFilter"),
+```
+
+## Uso rápido
+
+```swift
+import ProfanityFilter
+
+// Predeterminado: emoji + lista en inglés incluida
+let cleaned = ProfanityFilter.default.censor("What the fuck?")
+// "What the 😲😲😲😲?"
+
+// Azúcar en String
+let also = "What the fuck?".censored()
+```
+
+`cleanUp` sigue funcionando pero está deprecado — usa `censor` / `censored()`.
+
+## Personalización
+
+### Estilo de sustitución
+
+```swift
+let stars = ProfanityFilter(
+  replacement: .repeating("*"),
+  languageMode: .fixed(.english),
+)
+stars.censor("fuck") // "****"
+
+let fixed = ProfanityFilter(
+  replacement: .fixed("[censored]"),
+  languageMode: .fixed(.english),
+)
+fixed.censor("fuck") // "[censored]"
+
+let bullets = ProfanityFilter(
+  replacement: .custom { String(repeating: "•", count: $0.count) },
+  languageMode: .fixed(.english),
+)
+```
+
+### Listas personalizadas
+
+```swift
+var list = WordList(words: ["red", "hot pink"])
+list = list.inserting(["green"]).removing(["red"])
+
+let filter = ProfanityFilter(
+  replacement: .repeating("*"),
+  wordList: list,
+)
+filter.censor("a hot pink car") // "a ******** car"
+```
+
+Una `wordList` personalizada ignora la detección de idioma: ese filtro siempre usa tu lista.
+
+## Modo de idioma
+
+La v1 incluye una lista en inglés. La detección queda lista para más idiomas después.
+
+```swift
+// Siempre inglés (predeterminado)
+ProfanityFilter(languageMode: .fixed(.english))
+
+// Detectar con NaturalLanguage; usar fallback si el texto es corto o la confianza es baja
+ProfanityFilter(languageMode: .automatic(fallback: .english))
+
+// Unión de todas las listas incluidas (más costoso; útil con texto mezclado)
+ProfanityFilter(languageMode: .allBundled)
+```
+
+**Aviso**
+
+- Cadenas muy cortas son poco fiables para detectar idioma. `.automatic` usa el fallback bajo un mínimo de longitud / confianza.
+- Texto mezclado es difícil; usa `.fixed` o `.allBundled` cuando conozcas el caso.
+- Aún no se incluyen listas que no sean inglés — añadir una después es un recurso hasheado más un caso de `Language`.
+
+## Listas de palabras en el repositorio
+
+Las listas incluidas son **digests HMAC-SHA256**, no texto plano. Evita guardar lenguaje ofensivo en git; es higiene, no secreto (con sal pública se pueden sondear diccionarios conocidos).
+
+Quien mantiene el paquete guarda el texto plano local en `Maintainer/` (ignorado por git). Ver [Maintainer/README.md](Maintainer/README.md).
+
+## Desarrollo
+
+```bash
+make lint          # SwiftLint
+make format        # SwiftFormat (escribe)
+make format-check  # SwiftFormat --lint (CI)
+make test          # swift test
+```
+
+CI ejecuta los mismos targets de Make en GitHub Actions (`lint` / `format` / `test`).
+
+Abre `Package.swift` en Xcode, elige el scheme **ProfanityFilter** (y su test plan compartido), destino **My Mac**, luego ⌘U.
+
+## Licencia
+
+MIT. Ver [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,123 @@
 # ProfanityFilter
-Profanity filter written in Swift using NSRegularExpressions
 
-Example usage:
+A configurable, on-device profanity filter for Apple platforms. Match once against an init-built index of salted word digests; replace matches with a style you choose.
 
-    let testWord = "naughty"
+[Español](README.es-ES.md)
 
-    // returns "😲😲😲😲😲😲😲"
-    let cleanedUpWord = ProfanityFilter.cleanUp(testWord)
+## Requirements
+
+- Swift 6.3+
+- iOS 18+ / macOS 15+ / tvOS 18+ / watchOS 11+ / visionOS 2+
+
+## Installation
+
+Add the package in Xcode (**File → Add Package Dependencies…**) or in `Package.swift`:
+
+```swift
+dependencies: [
+  .package(url: "https://github.com/AdrianBinDC/ProfanityFilter.git", from: "1.0.0"),
+],
+```
+
+Then depend on the product:
+
+```swift
+.product(name: "ProfanityFilter", package: "ProfanityFilter"),
+```
+
+## Quick start
+
+```swift
+import ProfanityFilter
+
+// Shared default: emoji replacement + bundled English list
+let cleaned = ProfanityFilter.default.censor("What the fuck?")
+// "What the 😲😲😲😲?"
+
+// String sugar
+let also = "What the fuck?".censored()
+```
+
+`cleanUp` still works but is deprecated — prefer `censor` / `censored()`.
+
+## Customization
+
+### Replacement style
+
+```swift
+let stars = ProfanityFilter(
+  replacement: .repeating("*"),
+  languageMode: .fixed(.english),
+)
+stars.censor("fuck") // "****"
+
+let fixed = ProfanityFilter(
+  replacement: .fixed("[censored]"),
+  languageMode: .fixed(.english),
+)
+fixed.censor("fuck") // "[censored]"
+
+let bullets = ProfanityFilter(
+  replacement: .custom { String(repeating: "•", count: $0.count) },
+  languageMode: .fixed(.english),
+)
+```
+
+### Custom word lists
+
+```swift
+var list = WordList(words: ["red", "hot pink"])
+list = list.inserting(["green"]).removing(["red"])
+
+let filter = ProfanityFilter(
+  replacement: .repeating("*"),
+  wordList: list,
+)
+filter.censor("a hot pink car") // "a ******** car"
+```
+
+A custom `wordList` ignores language detection — that filter always uses your list.
+
+## Language mode
+
+v1 ships an English bundled list. Detection is ready for more languages later.
+
+```swift
+// Always English (default)
+ProfanityFilter(languageMode: .fixed(.english))
+
+// Detect with NaturalLanguage; fall back when short / low confidence
+ProfanityFilter(languageMode: .automatic(fallback: .english))
+
+// Union of every bundled list (costlier; useful for mixed text)
+ProfanityFilter(languageMode: .allBundled)
+```
+
+**Caveats**
+
+- Very short strings are unreliable for detection (“fuck” alone may not look like English). `.automatic` uses the fallback below a minimum length / confidence.
+- Mixed-language text is hard; prefer `.fixed` or `.allBundled` when you know the mix.
+- Non-English lists are not shipped yet — adding one later is a hashed resource plus a `Language` case.
+
+## Word lists in the repo
+
+Bundled lists are **HMAC-SHA256 digests**, not plaintext. That keeps foul language out of git history; it is hygiene, not secrecy (a public salt means common dictionaries can still be probed).
+
+Maintainers keep local plaintext under `Maintainer/` (gitignored). See [Maintainer/README.md](Maintainer/README.md).
+
+## Development
+
+```bash
+make lint          # SwiftLint
+make format        # SwiftFormat (write)
+make format-check  # SwiftFormat --lint (CI)
+make test          # swift test
+```
+
+CI runs the same Make targets on GitHub Actions (`lint` / `format` / `test`).
+
+Open `Package.swift` in Xcode, select the **ProfanityFilter** scheme (and its shared test plan), destination **My Mac**, then ⌘U.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/Sources/ProfanityFilter/Language.swift
+++ b/Sources/ProfanityFilter/Language.swift
@@ -3,8 +3,12 @@
 
 import NaturalLanguage
 
-/// Bundled word-list languages. Add a `*.hashes` resource to extend.
+/// Bundled word-list languages.
+///
+/// The `rawValue` is the resource stem for `Resources/WordLists/<rawValue>.hashes`.
+/// Add a case and a matching digest file to ship another language.
 public enum Language: String, Sendable, CaseIterable, Hashable {
+  /// English (`en.hashes`).
   case english = "en"
 
   init?(nlLanguage: NLLanguage) {

--- a/Sources/ProfanityFilter/LanguageMode.swift
+++ b/Sources/ProfanityFilter/LanguageMode.swift
@@ -2,6 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 /// Selects which bundled word list(s) to apply when censoring.
+///
+/// Only languages with a committed `*.hashes` resource are available. v1 ships
+/// English; additional languages can be added without changing this enum’s cases
+/// beyond a new ``Language`` value.
+///
+/// ### Automatic detection
+///
+/// ``automatic(fallback:)`` uses `NLLanguageRecognizer`. Short strings and
+/// low-confidence hypotheses fall back to `fallback` — detection alone is not
+/// reliable for a single expletive.
 public enum LanguageMode: Sendable, Equatable {
   /// Detect the text language, then use that list when available.
   ///

--- a/Sources/ProfanityFilter/ProfanityFilter.swift
+++ b/Sources/ProfanityFilter/ProfanityFilter.swift
@@ -2,10 +2,25 @@
 // SPDX-License-Identifier: MIT
 
 /// A configurable, init-once profanity filter for Apple platforms.
+///
+/// Build a filter with a ``Replacement`` style and either a ``LanguageMode``
+/// (bundled lists) or a custom ``WordList``. Matching uses an init-built index of
+/// salted digests so the hot path is tokenize → hash → set lookup.
+///
+/// ### Examples
+///
+/// ```swift
+/// let cleaned = ProfanityFilter.default.censor("What the fuck?")
+/// let stars = ProfanityFilter(
+///   replacement: .repeating("*"),
+///   languageMode: .fixed(.english),
+/// )
+/// ```
 public struct ProfanityFilter: Sendable {
   /// Shared default filter (emoji replacement + fixed English list).
   public static let `default` = ProfanityFilter()
 
+  /// How matched substrings are rewritten.
   public let replacement: Replacement
 
   /// Language selection for bundled lists. `nil` when constructed with a custom ``WordList``.
@@ -17,6 +32,10 @@ public struct ProfanityFilter: Sendable {
   private let customIndex: MatchIndex?
 
   /// Creates a filter that selects bundled lists according to `languageMode`.
+  ///
+  /// - Parameters:
+  ///   - replacement: Substitution style for matches. Defaults to repeating `😲`.
+  ///   - languageMode: Which bundled list(s) to use. Defaults to fixed English.
   public init(
     replacement: Replacement = .default,
     languageMode: LanguageMode = .fixed(.english),
@@ -28,6 +47,10 @@ public struct ProfanityFilter: Sendable {
   }
 
   /// Creates a filter that always uses a caller-provided word list (no language detection).
+  ///
+  /// - Parameters:
+  ///   - replacement: Substitution style for matches. Defaults to repeating `😲`.
+  ///   - wordList: Plaintext or digest-backed list hashed into a private index at init.
   public init(
     replacement: Replacement = .default,
     wordList: WordList,
@@ -39,6 +62,8 @@ public struct ProfanityFilter: Sendable {
   }
 
   /// Returns a copy of `string` with known profanity replaced.
+  ///
+  /// Matches are applied from the end of the string so earlier ranges stay valid.
   public func censor(_ string: String) -> String {
     let index = resolveIndex(for: string)
     let ranges = index.matches(in: string)
@@ -52,7 +77,7 @@ public struct ProfanityFilter: Sendable {
     return result
   }
 
-  /// Legacy entry point. Prefer ``censor(_:)`` or `String.censored()`.
+  /// Legacy entry point. Prefer ``censor(_:)`` or ``String/censored()``.
   @available(*, deprecated, message: "Use ProfanityFilter.censor(_:) or String.censored()")
   public static func cleanUp(_ string: String) -> String {
     ProfanityFilter.default.censor(string)

--- a/Sources/ProfanityFilter/Replacement.swift
+++ b/Sources/ProfanityFilter/Replacement.swift
@@ -3,7 +3,9 @@
 
 /// How matched profanity is rewritten in the output string.
 public enum Replacement: Sendable {
-  /// Repeat `unit` until the replacement length matches the match (default: `😲`).
+  /// Repeat `unit` until the replacement length matches the match (default unit: `😲`).
+  ///
+  /// For a single-character `unit`, the result length equals the match’s character count.
   case repeating(String)
 
   /// Always substitute this fixed string, regardless of match length.

--- a/Sources/ProfanityFilter/String+ProfanityFilter.swift
+++ b/Sources/ProfanityFilter/String+ProfanityFilter.swift
@@ -3,6 +3,9 @@
 
 public extension String {
   /// Returns a censored copy using ``ProfanityFilter/default``.
+  ///
+  /// Prefer configuring a ``ProfanityFilter`` when you need a custom
+  /// ``Replacement`` or ``LanguageMode``.
   func censored() -> String {
     censored(using: .default)
   }

--- a/Sources/ProfanityFilter/WordList.swift
+++ b/Sources/ProfanityFilter/WordList.swift
@@ -3,7 +3,12 @@
 
 import Foundation
 
-/// A set of words/phrases used to build a ``MatchIndex``.
+/// A set of words and phrases used to build a match index.
+///
+/// Callers may supply plaintext via ``init(words:)``, load a bundled digest file
+/// with ``bundled(for:)``, or derive variants with ``inserting(_:)`` /
+/// ``removing(_:)``. Digests are HMAC-SHA256 over normalized entries; the
+/// committed package resources never contain the plaintext corpus.
 public struct WordList: Sendable, Hashable {
   enum Storage: Hashable {
     case words(Set<String>)
@@ -17,13 +22,15 @@ public struct WordList: Sendable, Hashable {
 
   let storage: Storage
 
-  /// Creates a list from plaintext words (normalized at index build time).
+  /// Creates a list from plaintext words (normalized when the index is built).
   public init(words: some Sequence<String>) {
     let normalized = Set(words.map(WordDigest.normalize).filter { !$0.isEmpty })
     storage = .words(normalized)
   }
 
   /// Loads the bundled hashed list for `language`.
+  ///
+  /// - Precondition: The package must contain `<language.rawValue>.hashes`.
   public static func bundled(for language: Language) -> WordList {
     guard let list = bundledIfPresent(for: language) else {
       preconditionFailure("Missing bundled word list for \(language.rawValue)")
@@ -31,7 +38,7 @@ public struct WordList: Sendable, Hashable {
     return list
   }
 
-  /// Union of every bundled language list that is present in the package resources.
+  /// Union of every bundled language list present in the package resources.
   public static func allBundled() -> WordList {
     var combined: [DigestEntry] = []
     var seen = Set<Data>()
@@ -64,6 +71,7 @@ public struct WordList: Sendable, Hashable {
     return loadDigests(from: url)
   }
 
+  /// Returns a list with `words` added (hashed when storage is digest-backed).
   public func inserting(_ words: some Sequence<String>) -> WordList {
     switch storage {
     case var .words(existing):
@@ -87,6 +95,7 @@ public struct WordList: Sendable, Hashable {
     }
   }
 
+  /// Returns a list with `words` removed (by normalized form / digest).
   public func removing(_ words: some Sequence<String>) -> WordList {
     let toRemove = Set(words.map(WordDigest.normalize).filter { !$0.isEmpty })
     switch storage {


### PR DESCRIPTION
## Summary
- Rewrite English README for SPM install, `censor`/`Replacement`/`LanguageMode`, short-text caveats, and hashed word lists
- Sync `README.es-ES.md` to the same API surface
- Expand DocC on public types; flesh out `Maintainer/README.md`

## Test plan
- [x] `make lint` / `make format-check` / `make test` (21 tests)
- [ ] Skim README install snippet against a fresh SPM dependency after `1.0.0` tag
- [ ] Optional follow-up: tag `1.0.0` and refresh the GitHub repo description


Made with [Cursor](https://cursor.com)