### PR TITLE
Polish package front door for 1.1.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,10 +1,8 @@
-# Starter config — tighten once the word list leaves the source file.
 disabled_rules:
   - line_length
   - file_length
   - type_body_length
   - function_body_length
-  - todo
 
 opt_in_rules:
   - empty_count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] — 2026-08-02
+
+### Added
+
+- Bundled word lists for English, Spanish, French, Irish, Arabic, and Chinese
+- `make sync-wordlists` to refresh digests from [coffee-and-fun/google-profanity-words](https://github.com/coffee-and-fun/google-profanity-words)
+- Daily GitHub Actions workflow that opens a PR when upstream releases change digests
+- MIT third-party attribution in `THIRD_PARTY_NOTICES.md`
+
+## [1.0.0] — 2026-08-02
+
+### Added
+
+- Configurable `ProfanityFilter` with `Replacement` (repeating / fixed / custom)
+- Init-once `MatchIndex` matching over salted HMAC digests (English list bundled)
+- `LanguageMode` (fixed / automatic / allBundled) via NaturalLanguage
+- `String.censored()` convenience; deprecated `cleanUp` aliases
+- Swift 6.3 tools, Apple multi-platform floors, GitHub Actions CI
+
+[1.1.0]: https://github.com/AdrianBinDC/ProfanityFilter/releases/tag/1.1.0
+[1.0.0]: https://github.com/AdrianBinDC/ProfanityFilter/releases/tag/1.0.0

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,13 +1,21 @@
 # ProfanityFilter
 
+[![CI](https://github.com/AdrianBinDC/ProfanityFilter/actions/workflows/ci.yml/badge.svg)](https://github.com/AdrianBinDC/ProfanityFilter/actions/workflows/ci.yml)
+[![Swift 6.3+](https://img.shields.io/badge/Swift-6.3+-F05138?logo=swift&logoColor=white)](https://swift.org)
+[![Platforms](https://img.shields.io/badge/platforms-iOS%2018%20%7C%20macOS%2015%20%7C%20tvOS%2018%20%7C%20watchOS%2011%20%7C%20visionOS%202-lightgrey)](Package.swift)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/AdrianBinDC/ProfanityFilter)](https://github.com/AdrianBinDC/ProfanityFilter/releases)
+
 Filtro de lenguaje inapropiado configurable, en el dispositivo, para plataformas Apple. Construye un índice una vez (digests con sal) y sustituye coincidencias con el estilo que elijas.
 
-[English](README.md)
+[English](README.md) · [Changelog](CHANGELOG.md)
 
 ## Requisitos
 
 - Swift 6.3+
 - iOS 18+ / macOS 15+ / tvOS 18+ / watchOS 11+ / visionOS 2+
+
+Los mínimos de plataforma siguen a `Synchronization.Mutex` (concurrencia de Swift 6). Versiones anteriores no están soportadas.
 
 ## Instalación
 
@@ -15,7 +23,7 @@ Añade el paquete en Xcode (**File → Add Package Dependencies…**) o en `Pack
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/AdrianBinDC/ProfanityFilter.git", from: "1.0.0"),
+  .package(url: "https://github.com/AdrianBinDC/ProfanityFilter.git", from: "1.1.0"),
 ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # ProfanityFilter
 
+[![CI](https://github.com/AdrianBinDC/ProfanityFilter/actions/workflows/ci.yml/badge.svg)](https://github.com/AdrianBinDC/ProfanityFilter/actions/workflows/ci.yml)
+[![Swift 6.3+](https://img.shields.io/badge/Swift-6.3+-F05138?logo=swift&logoColor=white)](https://swift.org)
+[![Platforms](https://img.shields.io/badge/platforms-iOS%2018%20%7C%20macOS%2015%20%7C%20tvOS%2018%20%7C%20watchOS%2011%20%7C%20visionOS%202-lightgrey)](Package.swift)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/AdrianBinDC/ProfanityFilter)](https://github.com/AdrianBinDC/ProfanityFilter/releases)
+
 A configurable, on-device profanity filter for Apple platforms. Match once against an init-built index of salted word digests; replace matches with a style you choose.
 
-[Español](README.es-ES.md)
+[Español](README.es-ES.md) · [Changelog](CHANGELOG.md)
 
 ## Requirements
 
 - Swift 6.3+
 - iOS 18+ / macOS 15+ / tvOS 18+ / watchOS 11+ / visionOS 2+
+
+Platform floors track `Synchronization.Mutex` (Swift 6 concurrency). Older OS versions are not supported.
 
 ## Installation
 
@@ -15,7 +23,7 @@ Add the package in Xcode (**File → Add Package Dependencies…**) or in `Packa
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/AdrianBinDC/ProfanityFilter.git", from: "1.0.0"),
+  .package(url: "https://github.com/AdrianBinDC/ProfanityFilter.git", from: "1.1.0"),
 ],
 ```
 


### PR DESCRIPTION
## Summary
- Pin install examples to `1.1.0` and add CI / Swift / platform / license / release badges on both READMEs
- Add a Keep a Changelog `CHANGELOG.md` for 1.0.0 and 1.1.0, linked from the READMEs
- Note the `Mutex`-driven platform floors and drop the stale SwiftLint “starter” wording / disabled `todo` rule

## Test plan
- [ ] Confirm README badges render on GitHub
- [ ] Confirm install snippet shows `from: "1.1.0"`
- [ ] Open `CHANGELOG.md` and verify release links
- [ ] Spot-check Spanish README mirrors the English polish